### PR TITLE
Upgraded AI for Science for TF 23.06 NGC

### DIFF
--- a/hpc_ai/ai_science_climate/Dockerfile
+++ b/hpc_ai/ai_science_climate/Dockerfile
@@ -1,23 +1,17 @@
-# Copyright (c) 2020 NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2023 NVIDIA Corporation.  All rights reserved.
 
 # To build the docker container, run: $ sudo docker build -t ai-science-climate:latest --network=host .
 # To run: $ sudo docker run --rm -it --gpus=all --network=host -p 8888:8888 ai-science-climate:latest
 # Finally, open http://127.0.0.1:8888/
 
 # Select Base Image 
-FROM nvcr.io/nvidia/tensorflow:21.05-tf2-py3
+FROM nvcr.io/nvidia/tensorflow:23.06-tf2-py3
 # Update the repo
 RUN apt-get update -y
 # Install required dependencies
 RUN apt-get install -y libsm6 libxext6 libxrender-dev git nvidia-modprobe
 # Install required python packages
-RUN pip3 install  opencv-python==4.1.2.30 pandas==1.3.5 seaborn sklearn matplotlib scikit-fmm tqdm h5py gdown
-RUN pip3 install --upgrade pip
-RUN apt-get update -y        
-RUN apt-get install -y git nvidia-modprobe
-RUN pip3 install jupyterlab
-# Install required python packages
-RUN pip3 install ipywidgets
+RUN pip3 install opencv-python gdown
 
 ##### TODO - From the Final Repo Changing this 
 

--- a/hpc_ai/ai_science_climate/English/python/jupyter_notebook/Tropical_Cyclone_Intensity_Estimation/Competition.ipynb
+++ b/hpc_ai/ai_science_climate/English/python/jupyter_notebook/Tropical_Cyclone_Intensity_Estimation/Competition.ipynb
@@ -264,7 +264,7 @@
     "\n",
     "## ~~ Change Optimizer or Parameters Here\n",
     "# Optimizer\n",
-    "sgd = tensorflow.keras.optimizers.SGD(lr=0.001, decay=1e-6, momentum=0.9)\n",
+    "sgd = tensorflow.keras.optimizers.legacy.SGD(lr=0.001, decay=1e-6, momentum=0.9)\n",
     "## ~~ Change Optimizer or Parameters Here\n",
     "\n",
     "#Compile Model with Loss Function , Optimizer and Metrics\n",
@@ -396,7 +396,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -410,9 +410,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/hpc_ai/ai_science_climate/English/python/jupyter_notebook/Tropical_Cyclone_Intensity_Estimation/Countering_Data_Imbalance.ipynb
+++ b/hpc_ai/ai_science_climate/English/python/jupyter_notebook/Tropical_Cyclone_Intensity_Estimation/Countering_Data_Imbalance.ipynb
@@ -82,7 +82,8 @@
    "source": [
     "First thing that we will notice from the category count is that the number of images per category is very un-uniform with ratios of TC: H5 **greater than 1:20**, This imbalance can bias the vision of our CNN model because predicting wrong on the minority class wouldn't impact the model a lot as the class contribution is less than 5% of the dataset.\n",
     "\n",
-    "The same can be shown also by the heatmap we obtained in the previous notebook : Notice Most of Classes with higher data was predicted correctly and the minority class was more mis-predicted than the other classes \n",
+    "The same can be shown also by the heatmap we obtained in the previous notebook : Notice Most of Classes with higher data was predicted correctly and the minority class was more mis-predicted than the other classes\n",
+    "\n",
     "![alt_text](images/heatmap.png)\n",
     "\n",
     "\n",
@@ -316,7 +317,7 @@
     "model.load_weights(\"trained_16.h5\")\n",
     "\n",
     "# Optimizer\n",
-    "sgd = tensorflow.keras.optimizers.SGD(lr=0.001, decay=1e-6, momentum=0.9)\n",
+    "sgd = tensorflow.keras.optimizers.legacy.SGD(lr=0.001, decay=1e-6, momentum=0.9)\n",
     "\n",
     "\n",
     "#Compile Model with Loss Function , Optimizer and Metrics\n",
@@ -451,7 +452,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -465,9 +466,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/hpc_ai/ai_science_climate/English/python/jupyter_notebook/Tropical_Cyclone_Intensity_Estimation/Manipulation_of_Image_Data_and_Category_Determination_using_Text_Data.ipynb
+++ b/hpc_ai/ai_science_climate/English/python/jupyter_notebook/Tropical_Cyclone_Intensity_Estimation/Manipulation_of_Image_Data_and_Category_Determination_using_Text_Data.ipynb
@@ -544,7 +544,7 @@
     "model.load_weights(\"trained_16.h5\")\n",
     "\n",
     "# Optimizer\n",
-    "sgd = tensorflow.keras.optimizers.SGD(lr=0.001, decay=1e-6, momentum=0.9)\n",
+    "sgd = tensorflow.keras.optimizers.legacy.SGD(lr=0.001, decay=1e-6, momentum=0.9)\n",
     "\n",
     "\n",
     "#Compile Model with Loss Function , Optimizer and Metrics\n",
@@ -616,9 +616,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import seaborn as sn\n",
@@ -689,7 +687,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -703,9 +701,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/hpc_ai/ai_science_climate/README.MD
+++ b/hpc_ai/ai_science_climate/README.MD
@@ -41,14 +41,14 @@ Start working on the lab by clicking on the `Start_Here.ipynb` notebook.
 ### Singularity Container
 
 To build the singularity container, run: 
-`sudo singularity build <image_name>.simg Singularity`
+`sudo singularity build <image_name>.sif Singularity`
 
 and copy the files to your local machine to make sure changes are stored locally:
-`singularity run <image_name>.simg cp -rT /workspace ~/workspace`
+`singularity run <image_name>.sif cp -rT /workspace ~/workspace`
 
 
 Then, run the container:
-`singularity run --nv <image_name>.simg jupyter-lab --notebook-dir=~/workspace/python/jupyter_notebook`
+`singularity run --nv --no-home -B /home/$USER/workspace --writable-tmpfs --env JUPYTER_RUNTIME_DIR=~/workspace/.jupyter/runtime <image_name>.sif jupyter-lab --notebook-dir=~/workspace/python/jupyter_notebook`
 
 Then, open the jupyter lab in browser: http://localhost:8888
 Start working on the lab by clicking on the `Start_Here.ipynb` notebook.

--- a/hpc_ai/ai_science_climate/Singularity
+++ b/hpc_ai/ai_science_climate/Singularity
@@ -1,21 +1,15 @@
-# Copyright (c) 2020 NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2023 NVIDIA Corporation.  All rights reserved.
 
 Bootstrap: docker
-FROM: nvcr.io/nvidia/tensorflow:21.05-tf2-py3
+FROM: nvcr.io/nvidia/tensorflow:23.06-tf2-py3
 
 %environment
 %post
     apt-get update -y
     apt-get install -y libsm6 libxext6 libxrender-dev git 
-    pip3 install  opencv-python==4.1.2.30 pandas==1.3.5 seaborn sklearn matplotlib scikit-fmm tqdm h5py gdown
+    pip3 install opencv-python gdown
     python3 /workspace/python/source_code/dataset.py
-    
-    pip3 install --upgrade pip
-    apt-get update -y
-    apt-get -y install git nvidia-modprobe
-    pip3 install jupyterlab
-    pip3 install ipywidgets
-    
+        
 %files
     English/* /workspace/
 


### PR DESCRIPTION
AI for Science material would break since the OpenCV version fixed in the Singularity and Docker file was removed from Python Package Index. Hence the following changes were made: 

- Ported the material with the latest TF NGC container ( 23.06 ) 
- Uses the latest OpenCV version for the operations in the notebooks.
- Updated the README to use the SIF format used in Singularity 3.x versions
- Removed unwanted dependency upgrades that were already present in the NGC container.
